### PR TITLE
Fix the screen sharing issue in Windows

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -120,7 +120,9 @@ const createWindow = async () => {
     mainWindow.resizable = false;
     mainWindow.minimizable = false;
     mainWindow.maximizable = false;
-    mainWindow.setWindowButtonVisibility(false);
+    if (typeof mainWindow.setWindowButtonVisibility === 'function') {
+      mainWindow.setWindowButtonVisibility(false);
+    }
     // In macOS Electron, long titles may be truncated.
     mainWindow.setTitle('MyClassroom');
 
@@ -141,7 +143,9 @@ const createWindow = async () => {
     mainWindow.resizable = true;
     mainWindow.minimizable = true;
     mainWindow.maximizable = true;
-    mainWindow.setWindowButtonVisibility(true);
+    if (typeof mainWindow.setWindowButtonVisibility === 'function') {
+      mainWindow.setWindowButtonVisibility(true);
+    }
     mainWindow.setTitle('MyClassroom');
 
     event.reply('chime-disable-screen-share-mode-ack');


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-chime-sdk-classroom-demo/issues/5

*Description of changes:*
- Fix the issue in Windows that the `BrowserWindow.setWindowButtonVisibility` error shows up when sharing screen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
