### PR TITLE
Deploy DMG file insetad of zip and fix the ENOENT error in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "chalk": "^3.0.0",
     "concurrently": "^5.0.2",
     "cross-env": "^7.0.0",
-    "cross-spawn": "^7.0.1",
+    "cross-spawn": "^7.0.2",
     "css-loader": "^3.4.2",
     "detect-port": "^1.3.0",
     "electron": "7.1.13",

--- a/script/deploy.js
+++ b/script/deploy.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { spawnSync } = require('child_process');
+const spawnSync = require('cross-spawn').sync;
 const fs = require('fs');
 const path = require('path');
 
@@ -198,7 +198,7 @@ ${cssStyle}
 <article class="markdown-body">
 <h3>Download ${appName}</h3>
 <ul>
-<li><a href="https://${bucket}-releases.s3.amazonaws.com/mac/${appName}.zip">${appName} for macOS (ZIP)</a></li>
+<li><a href="https://${bucket}-releases.s3.amazonaws.com/mac/${appName}.dmg">${appName} for macOS (DMG)</a></li>
 <li><a href="https://${bucket}-releases.s3.amazonaws.com/win/${appName}.zip">${appName} for Windows (ZIP)</a></li>
 </ul>
 </article>
@@ -312,8 +312,8 @@ export default function getMessagingWssUrl() {return '${messagingWssUrl}';}
     'cp',
     '--acl',
     'public-read',
-    `release/${appName}.zip`,
-    `s3://${bucket}-releases/mac/${appName}.zip`
+    `release/${appName}.dmg`,
+    `s3://${bucket}-releases/mac/${appName}.dmg`
   ]);
 
   console.log('... uploading Windows installer (this may take a while) ...');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4997,6 +4997,15 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
+  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cross-unzip@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"


### PR DESCRIPTION
*Issue #, if available:*
This PR might fix https://github.com/aws-samples/amazon-chime-sdk-classroom-demo/issues/1 or/and https://github.com/aws-samples/amazon-chime-sdk-classroom-demo/issues/2.

*Description of changes:*
- Deploy DMG file instead of ZIP. The `electron-builder` library has an ongoing issue that users can't open the macOS app unzipped from the ZIP file. People reported that distributing DMG file works instead.
https://github.com/electron-userland/electron-builder/issues/4299

- Fix the ENOENT error in Windows that happened when running the `spawnSync` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
