### PR TITLE
Fix the ENOENT issue in Windows

### DIFF
--- a/script/deploy.js
+++ b/script/deploy.js
@@ -126,6 +126,10 @@ function parseArgs() {
 }
 
 function spawnOrFail(command, args, options) {
+  options = {
+    ...options,
+    shell: true
+  };
   console.log(`--> ${command} ${args.join(' ')}`);
   const cmd = spawnSync(command, args, options);
   if (cmd.error) {


### PR DESCRIPTION
*Issue #, if available:*
Fix https://github.com/aws-samples/amazon-chime-sdk-classroom-demo/issues/2

*Description of changes:*
- Fix the ENOENT issue when running NPM's spawnSync

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
