### PR TITLE
Fixes the deletion of items on disconnect event of messaging

### DIFF
--- a/serverless/src/messaging.js
+++ b/serverless/src/messaging.js
@@ -109,12 +109,12 @@ exports.ondisconnect = async event => {
   console.log('ondisconnect event:', JSON.stringify(event, null, 2));
   try {
     await ddb
-      .delete({
+      .deleteItem({
         TableName: process.env.CONNECTIONS_TABLE_NAME,
         Key: {
-          MeetingId: event.requestContext.authorizer.MeetingId,
-          AttendeeId: event.requestContext.authorizer.AttendeeId
-        }
+          MeetingId: { S: event.requestContext.authorizer.MeetingId },
+          AttendeeId: { S: event.requestContext.authorizer.AttendeeId },
+        },
       })
       .promise();
   } catch (err) {


### PR DESCRIPTION
*Issue #, if available:*
The query to delete item from dynamo db, on disconnect event of WebSocket had a mistake which resulted in the below error.
TypeError: ddb.delete is not a function
    at Runtime.exports.ondisconnect [as handler] (/var/task/messaging.js:130:14)
    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)
*Description of changes:*
Changed the query to fix the deletion of items when the websocket is disconnected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
